### PR TITLE
[PH-쿼리무효화-키수정] 일정 수정/신청서 취소 후 목록 미갱신 버그 수정

### DIFF
--- a/src/hooks/useProposal.ts
+++ b/src/hooks/useProposal.ts
@@ -106,7 +106,7 @@ export const useCancelProposal = (meetupId: number) => {
       toast.success("신청서가 성공적으로 취소되었습니다.");
       // 필요하면 캐시 무효화
       queryClient.invalidateQueries({ queryKey: ["status", meetupId] });
-      queryClient.invalidateQueries({ queryKey: ["myMeetups", "organizer", "ongoing"] });
+      queryClient.invalidateQueries({ queryKey: ["myMeetups", "organizer"] });
       queryClient.invalidateQueries({ queryKey: ["sentProposals"] });
       queryClient.invalidateQueries({ queryKey: ["receivedProposals", meetupId] });
     },

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -49,7 +49,7 @@ export const useUpdateSchedule = (scheduleId: number) => {
   return useMutation({
     mutationFn: ({ scheduleId, payload }: { scheduleId: number; payload: SchedulePayload }) => updateSchedule(scheduleId, payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["schedules", scheduleId] });
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
       queryClient.invalidateQueries({ queryKey: ["schedule", scheduleId] });
     },
   });


### PR DESCRIPTION
## 변경 사항
- `useUpdateSchedule`: 무효화 키가 `["schedules", scheduleId]`였으나 실제 목록 키는 `["schedules", meetupId]` → prefix `["schedules"]`로 무효화하도록 수정. 일정 수정 후 목록이 갱신되지 않던 문제 해결.
- `useCancelProposal`: 실제 쿼리에 존재하지 않는 `"ongoing"` 세그먼트를 키에 포함해 무효화가 매칭되지 않던 문제 → `["myMeetups", "organizer"]`로 수정.

## 테스트
- [x] `yarn build` 통과
- [ ] 일정 수정 후 목록 즉시 반영 확인
- [ ] 신청서 취소 후 방장 모임 목록 갱신 확인